### PR TITLE
Fix dependencies requirements.txt #1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.0
+Django==4.1
 pycryptodome==3.15.0
 djangorestframework==3.14.0
 django-cors-headers==3.13.0


### PR DESCRIPTION
Fix bug with

The conflict is caused by:
    The user requested Django==2.0
    djangorestframework 3.14.0 depends on django>=3.0